### PR TITLE
feat(#138): Add async context manager to SpriteForgeWorkflow

### DIFF
--- a/scripts/example_factory.py
+++ b/scripts/example_factory.py
@@ -34,36 +34,27 @@ async def main() -> None:
     print("Creating workflow with tiered model architecture...")
 
     try:
-        workflow = await create_workflow(
-            config=config,
-            # project_endpoint can be omitted - falls back to AZURE_AI_PROJECT_ENDPOINT env var
-            # credential can be omitted - factory creates DefaultAzureCredential
-        )
+        async with await create_workflow(config=config) as workflow:
+            print("✓ Workflow created successfully")
+            print(f"  Grid generator: {type(workflow.grid_generator).__name__}")
+            print(f"  Gate checker: {type(workflow.gate_checker).__name__}")
+            print(f"  Reference provider: {type(workflow.reference_provider).__name__}")
+
+            # To run the full pipeline (expensive - generates spritesheet):
+            # output_path = Path("output") / f"{config.character.name.lower()}_spritesheet.png"
+            # output_path.parent.mkdir(exist_ok=True)
+            # result = await workflow.run(
+            #     base_reference_path=config.base_image_path,
+            #     output_path=output_path,
+            # )
+            # print(f"\n✓ Spritesheet generated: {result}")
+
+        print("\n✓ Resources cleaned up")
     except Exception as e:
         print(f"✗ Could not create workflow: {e}")
         print("\nNote: This example requires Azure AI Foundry credentials.")
         print("Set AZURE_AI_PROJECT_ENDPOINT environment variable to run.")
         return
-
-    try:
-        print("✓ Workflow created successfully")
-        print(f"  Grid generator: {type(workflow.grid_generator).__name__}")
-        print(f"  Gate checker: {type(workflow.gate_checker).__name__}")
-        print(f"  Reference provider: {type(workflow.reference_provider).__name__}")
-
-        # To run the full pipeline (expensive - generates spritesheet):
-        # output_path = Path("output") / f"{config.character.name.lower()}_spritesheet.png"
-        # output_path.parent.mkdir(exist_ok=True)
-        # result = await workflow.run(
-        #     base_reference_path=config.base_image_path,
-        #     output_path=output_path,
-        # )
-        # print(f"\n✓ Spritesheet generated: {result}")
-
-    finally:
-        # Always clean up resources
-        await workflow.close()
-        print("\n✓ Resources cleaned up")
 
 
 if __name__ == "__main__":

--- a/src/spriteforge/cli.py
+++ b/src/spriteforge/cli.py
@@ -255,25 +255,20 @@ async def _run_generation(
 
         # Create workflow
         with console.status("[bold blue]Creating workflow..."):
-            workflow = await create_workflow(
+            async with await create_workflow(
                 config=config,
                 max_concurrent_rows=max_concurrent_rows,
                 checkpoint_dir=checkpoint_dir,
-            )
+            ) as workflow:
+                # Run generation
+                result = await workflow.run(
+                    base_reference_path=base_reference_path,
+                    output_path=output_path,
+                    progress_callback=progress_callback,
+                )
 
-        try:
-            # Run generation
-            result = await workflow.run(
-                base_reference_path=base_reference_path,
-                output_path=output_path,
-                progress_callback=progress_callback,
-            )
-
-            console.print()
-            console.print(f"[bold green]✓[/] Spritesheet generated: [bold]{result}[/]")
-
-        finally:
-            await workflow.close()
+        console.print()
+        console.print(f"[bold green]✓[/] Spritesheet generated: [bold]{result}[/]")
 
 
 @main.command()

--- a/src/spriteforge/workflow.py
+++ b/src/spriteforge/workflow.py
@@ -130,6 +130,14 @@ class SpriteForgeWorkflow:
         else:
             self.frame_generator = frame_generator
 
+    async def __aenter__(self) -> "SpriteForgeWorkflow":
+        """Enter the async context manager. Returns self."""
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        """Exit the async context manager, closing all resources."""
+        await self.close()
+
     async def close(self) -> None:
         """Clean up all provider resources.
 
@@ -1029,14 +1037,11 @@ async def create_workflow(
     Example::
 
         config = load_config("configs/theron.yaml")
-        workflow = await create_workflow(config)
-        try:
+        async with await create_workflow(config) as workflow:
             await workflow.run(
                 base_reference_path="docs_assets/theron_base_reference.png",
                 output_path="output/theron_spritesheet.png",
             )
-        finally:
-            await workflow.close()
     """
     import os
 


### PR DESCRIPTION
## Summary

Resolves #138 — Add async context manager support to `SpriteForgeWorkflow`.

### Changes

**`src/spriteforge/workflow.py`**
- Added `__aenter__` / `__aexit__` to `SpriteForgeWorkflow` — non-breaking additive change
- Updated `create_workflow()` docstring to show `async with await create_workflow(config) as workflow:` pattern

**`src/spriteforge/cli.py`**
- Converted `_run_generation` from `try/finally + close()` to `async with await create_workflow(...) as workflow:`

**`scripts/example_factory.py`**
- Converted to `async with await create_workflow(config) as workflow:` pattern

**`tests/test_workflow.py`**
- All 5 factory tests + 1 integration test: converted from bare `await workflow.close()` to `async with await create_workflow(...) as workflow:`
- `test_workflow_close_cleans_all` and `test_workflow_close_with_owned_credential` kept with explicit `close()` — these tests the close behavior itself

**`tests/test_checkpoint_workflow.py`**
- All 4 tests converted to `async with SpriteForgeWorkflow(...) as workflow:` — resources now guaranteed to be released even if assertions fail

### Acceptance Criteria

- [x] `SpriteForgeWorkflow` implements `__aenter__` and `__aexit__`
- [x] `async with await create_workflow(...) as wf:` works correctly
- [x] `cli.py` uses `async with` instead of `try/finally`
- [x] `scripts/example_factory.py` uses `async with`
- [x] All test files: no bare `close()` outside `finally` (except tests specifically testing close behavior)
- [x] `create_workflow()` docstring updated to prefer `async with`
- [x] All existing tests pass (`pytest` — 577 passed, 14 skipped)
